### PR TITLE
Multiple adjustments

### DIFF
--- a/hugo_jupyter/__fabfile.py
+++ b/hugo_jupyter/__fabfile.py
@@ -1,48 +1,54 @@
-import re
 import json
-import sys
+import re
 import shlex
+import shutil
 import subprocess as sp
-from pathlib import Path
+import sys
+import webbrowser
 from datetime import datetime
-from collections import defaultdict
+from pathlib import Path
 from typing import *
+import time
 
+import crayons
 import nbformat
-
+from fabric.api import *
 from nbconvert import MarkdownExporter
 from nbconvert.preprocessors import Preprocessor
-
+from nbconvert.writers import FilesWriter
 from traitlets.config import Config
-
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
-import crayons
-
-from fabric.api import *
 
 @task
 def update_notebooks_metadata():
-    """Update all the notebooks' metadata fields."""
+    """Updates all the notebooks' metadata fields."""
+    # noinspection SpellCheckingInspection
     notebooks = Path('notebooks').glob('*.ipynb')
     for notebook in notebooks:
-        if (not str(notebook).startswith('.')) and ('untitled' not in str(notebook).lower()):
-            yield update_notebook_metadata(notebook)
+        if str(notebook).startswith('.'):
+            pass
+        elif 'untitled' in str(notebook).lower():
+            pass
+        else:
+            update_notebook_metadata(notebook)
+
 
 @task
 def render_notebooks():
+    """Renders jupyter notebooks it notebooks directory to respective markdown
+    in content/post directory.
     """
-    Render jupyter notebooks it notebooks directory to respective markdown in content/post directory.
-    """
-    for notebook in update_notebooks_metadata():
+    notebooks = Path('notebooks').glob('*.ipynb')
+    for notebook in notebooks:
         write_hugo_formatted_nb_to_md(notebook)
 
 
 @task
 def serve(hugo_args='', init_jupyter=True):
-    """
-    Watch for changes in jupyter notebooks and render them anew while hugo runs.
+    """Watches for changes in jupyter notebooks and render them anew while hugo
+    runs.
 
     Args:
         init_jupyter: initialize jupyter if set to True
@@ -57,7 +63,7 @@ def serve(hugo_args='', init_jupyter=True):
     if init_jupyter:
         jupyter_process = sp.Popen(('jupyter', 'notebook'), cwd='notebooks')
 
-    local('open http://localhost:1313')
+    webbrowser.open('http://localhost:1313')
 
     try:
         print(crayons.green('Successfully initialized server(s)'),
@@ -69,22 +75,22 @@ def serve(hugo_args='', init_jupyter=True):
         print(crayons.yellow('Terminating'))
     finally:
         if init_jupyter:
-            print(crayons.yellow('shutting down jupyter'))
+            print(crayons.yellow('Info - Shutting down jupyter'))
             jupyter_process.kill()
 
-        print(crayons.yellow('shutting down watchdog'))
+        print(crayons.yellow('Info - Shutting down watchdog'))
         observer.stop()
         observer.join()
-        print(crayons.yellow('shutting down hugo'))
+        print(crayons.yellow('Info - Shutting down hugo'))
         hugo_process.kill()
-        print(crayons.green('all processes shut down successfully'))
+        print(crayons.green('Info - All processes shut down successfully'))
         sys.exit(0)
 
 
 @task
 def publish():
     """
-    Publish notebook to github pages.
+    Publishes notebook to github pages.
 
     Assumes this is yourusername.github.io repo aka
     User Pages site as described in
@@ -95,7 +101,8 @@ def publish():
     with settings(warn_only=True):
         if local('git diff-index --quiet HEAD --').failed:
             local('git status')
-            abort('The working directory is dirty. Please commit any pending changes.')
+            abort('The working directory is dirty. Please commit any pending'
+                  'changes.')
 
     # deleting old publication
     local('rm -rf public')
@@ -123,25 +130,24 @@ def publish():
     print('push succeeded')
 
 
-########## Jupyter stuff #################
+# Jupyter stuff
 
 class CustomPreprocessor(Preprocessor):
-    """Remove blank code cells and unnecessary whitespace."""
+    """Removes blank code cells and unnecessary whitespace."""
 
     def preprocess(self, nb, resources):
-        """
-        Remove blank cells
+        """Remove blank cells
         """
         for index, cell in enumerate(nb.cells):
             if cell.cell_type == 'code' and not cell.source:
                 nb.cells.pop(index)
             else:
-                nb.cells[index], resources = self.preprocess_cell(cell, resources, index)
+                nb.cells[index], resources = self.preprocess_cell(
+                    cell, resources, index)
         return nb, resources
 
     def preprocess_cell(self, cell, resources, cell_index):
-        """
-        Remove extraneous whitespace from code cells' source code
+        """Removes extraneous whitespace from code cells' source code
         """
         if cell.cell_type == 'code':
             cell.source = cell.source.strip()
@@ -150,32 +156,32 @@ class CustomPreprocessor(Preprocessor):
 
 
 def doctor(string: str) -> str:
-    """Get rid of all the wacky newlines nbconvert adds to markdown output and return result."""
+    """Gets rid of all the wacky newlines nbconvert adds to markdown output and
+    return result."""
     post_code_newlines_patt = re.compile(r'(```)(\n+)')
     inter_output_newlines_patt = re.compile(r'(\s{4}\S+)(\n+)(\s{4})')
 
     post_code_filtered = re.sub(post_code_newlines_patt, r'\1\n\n', string)
-    inter_output_filtered = re.sub(inter_output_newlines_patt, r'\1\n\3', post_code_filtered)
+    inter_output_filtered = re.sub(
+        inter_output_newlines_patt, r'\1\n\3', post_code_filtered)
 
     return inter_output_filtered
 
 
-def notebook_to_markdown(path: Union[Path, str]) -> str:
-    """
-    Convert jupyter notebook to hugo-formatted markdown string
+def notebook_to_markdown(notebook_path: Union[Path, str]) -> Tuple[str, dict]:
+    """Converts jupyter notebook to hugo-formatted markdown string and returns
+    the markdown string along with the resources (e.g. images).
 
     Args:
-        path: path to notebook
+        notebook_path: path to notebook
 
-    Returns: hugo-formatted markdown
+    Returns:
+        output: markdown string
+        resources: dictionary containing additional notebook resources
 
     """
-    # first, update the notebook's metadata
-    update_notebook_metadata(path)
-
-    with open(Path(path)) as fp:
+    with open(notebook_path) as fp:
         notebook = nbformat.read(fp, as_version=4)
-        assert 'front-matter' in notebook['metadata'], "You must have a front-matter field in the notebook's metadata"
         front_matter_dict = dict(notebook['metadata']['front-matter'])
         front_matter = json.dumps(front_matter_dict, indent=2)
 
@@ -183,78 +189,122 @@ def notebook_to_markdown(path: Union[Path, str]) -> str:
     c.MarkdownExporter.preprocessors = [CustomPreprocessor]
     markdown_exporter = MarkdownExporter(config=c)
 
-    markdown, _ = markdown_exporter.from_notebook_node(notebook)
-    doctored_md = doctor(markdown)
+    markdown, resources = markdown_exporter.from_notebook_node(notebook)
+    markdown = doctor(markdown)
+
     # added <!--more--> comment to prevent summary creation
-    output = '\n'.join(('---', front_matter, '---', '<!--more-->', doctored_md))
+    markdown = '\n'.join(
+        ['---', front_matter, '---', '<!--more-->', markdown])
 
-    return output
+    return markdown, resources
 
 
-def write_hugo_formatted_nb_to_md(notebook: Union[Path, str], render_to: Optional[Union[Path, str]] = None) -> Path:
-    """
-    Convert Jupyter notebook to markdown and write it to the appropriate file.
+def write_hugo_formatted_nb_to_md(
+        notebook_path: Path,
+        render_to: Optional[Union[Path, str]] = None):
+    """Converts Jupyter notebook to markdown and writes the markdown file to the
+    ``content/`` and resources to ``static/resources``.
+
+    Note that, when the markdown file is placed in ``content/post/<name>.md``,
+    resources are located in ``static/resources/post/<name>/.
 
     Args:
-        notebook: The path to the notebook to be rendered
+        notebook_path: The path to the notebook to be rendered
         render_to: The directory we want to render the notebook to
     """
-    notebook = Path(notebook)
-    notebook_metadata = json.loads(notebook.read_text())['metadata']
-    rendered_markdown_string = notebook_to_markdown(notebook)
+    notebook_metadata = json.loads(notebook_path.read_text())['metadata']
+    rendered_md_string, rendered_md_resources = notebook_to_markdown(
+        notebook_path)
     slug = notebook_metadata['front-matter']['slug']
-    render_to = render_to or notebook_metadata['hugo-jupyter']['render-to'] or 'content/post/'
+    render_to = (render_to or notebook_metadata['hugo-jupyter']['render-to'] or
+                 'content/post/')
 
     if not render_to.endswith('/'):
         render_to += '/'
 
-    rendered_markdown_file = Path(render_to, slug + '.md')
+    rendered_md_path = Path(render_to, slug + '.md')
+    rendered_md_resources_path = Path(
+        f'static/resources/{rendered_md_path.parent.stem}/{slug}')
 
-    if not rendered_markdown_file.parent.exists():
-        rendered_markdown_file.parent.mkdir(parents=True)
+    if not rendered_md_path.parent.exists():
+        rendered_md_path.parent.mkdir(parents=True)
+    if not rendered_md_resources_path.exists():
+        rendered_md_resources_path.mkdir(parents=True)
 
-    rendered_markdown_file.write_text(rendered_markdown_string)
-    print(notebook.name, '->', rendered_markdown_file.name)
-    return rendered_markdown_file
+    # Adjust image paths to static
+    rendered_md_string = rendered_md_string.replace(
+        '![png](output_', f'![png](/resources/blog/{slug}/output_')
+
+    # Write markdown to render_to
+    c = Config()
+    c.FilesWriter.build_directory = str(rendered_md_path.parent)
+    fw = FilesWriter(config=c)
+    fw.write(output=rendered_md_string, resources={'output_extension': '.md'},
+             notebook_name=rendered_md_path.stem)
+    # Write resources to static if exist
+    if rendered_md_resources['outputs']:
+        c.FilesWriter.build_directory = str(rendered_md_resources_path)
+        fw = FilesWriter(config=c)
+        fw.write(output='', resources=rendered_md_resources,
+                 notebook_name=rendered_md_path.stem)
+        # Remove empty markdown created by writing resources
+        Path(rendered_md_resources_path, rendered_md_path.name).unlink()
+
+    # Print status message
+    print(notebook_path.name, '->', rendered_md_path.name)
 
 
-def update_notebook_metadata(notebook: Union[Path, str],
+def update_notebook_metadata(notebook_path: Path,
                              title: Union[None, str] = None,
                              subtitle: Union[None, str] = None,
                              date: Union[None, str] = None,
                              slug: Union[None, str] = None,
-                             render_to: str = None) -> Path:
-    """
-    Update the notebook's metadata for hugo rendering
+                             toc: Union[None, str] = None,
+                             render_to: str = None):
+    """Updates the notebook's metadata for hugo rendering.
 
     Args:
-        notebook: notebook to have edited
+        title: title of the post
+        subtitle: subtitle of the post
+        date: date of the post
+        slug: short name of the post with hyphens instead of whitespaces
+        notebook: path to notebook which needs metadata update
+        toc: identifier whether table of content should be displayed
+        render_to: destination path for rendered notebook
     """
-    notebook_path: Path = Path(notebook)
     notebook_data: dict = json.loads(notebook_path.read_text())
-    old_front_matter: dict = notebook_data.get('metadata', {}).get('front-matter', {})
+    old_front_matter: dict = notebook_data.get(
+        'metadata', {}).get('front-matter', {})
 
     # generate front-matter fields
     title = title or old_front_matter.get('title') or notebook_path.stem
-    subtitle = subtitle or old_front_matter.get('subtitle') or 'Generic subtitle'
-    date = date or old_front_matter.get('date') or datetime.now().strftime('%Y-%m-%d')
-    slug = slug or old_front_matter.get('slug') or title.lower().replace(' ', '-')
+    subtitle = (subtitle or old_front_matter.get('subtitle') or
+                'Generic subtitle')
+    date = (date or old_front_matter.get('date') or
+            datetime.now().strftime('%Y-%m-%d'))
+    slug = (slug or old_front_matter.get('slug') or
+            title.lower().replace(' ', '-'))
+    toc = toc or old_front_matter.get('toc') or 'true'
 
     front_matter = {
         'title': title,
         'subtitle': subtitle,
         'date': date,
         'slug': slug,
+        'toc': toc,
     }
 
     # update front-matter
     notebook_data['metadata']['front-matter'] = front_matter
 
     # update hugo-jupyter settings
-    render_to = render_to or notebook_data['metadata'].get('hugo-jupyter', {}).get('render-to') or 'content/post/'
+    render_to = render_to or notebook_data['metadata'].get(
+        'hugo-jupyter', {}).get('render-to') or 'content/post/'
+
     hugo_jupyter = {
         'render-to': render_to
     }
+
     notebook_data['metadata']['hugo-jupyter'] = hugo_jupyter
 
     # write over old notebook with new front-matter
@@ -263,76 +313,145 @@ def update_notebook_metadata(notebook: Union[Path, str],
     # make the notebook trusted again, now that we've changed it
     sp.run(['jupyter', 'trust', str(notebook_path)])
 
-    return notebook_path
+    print(f'Info - Changed notebook metadata for {notebook}')
 
 
-########## Watchdog stuff #################
+def update_notebook_name(notebook_path: Union[Path, str], slug):
+    """Renames the notebook so that it matches the slug of the article."""
+    new_notebook_path = Path(notebook).with_name(slug + '.ipynb')
+    # Rename file
+    notebook_path.replace(new_notebook_path)
+
+    print(f'Renamed {notebook_path} to {new_notebook_path}')
+
+
+# Watchdog stuff
 
 class NotebookHandler(PatternMatchingEventHandler):
-    patterns = ["*.ipynb"]
+    """Handles the processing of notebooks to Hugo posts based on file
+    events.
+
+    Attributes:
+        patterns (list): files to include
+        ignore_patterns (list): files to exclude
+    """
+    patterns = ['*.ipynb']
+    ignore_patterns = ['*.~*.ipynb', '*Untitled*.ipynb', ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
-        # a mapping of notebook filepaths and their respective metadata
-        self.notebook_metadata: Mapping[str, dict] = {}
-        # a mapping of notebook filepaths and where they were rendered to
-        self.notebook_render: Mapping[str, Set[Path]] = defaultdict(set)
 
     def process(self, event):
         try:
-            # don't automatically update front matter
-            # and render notebook until filename is
-            # changed from untitled...
-            if 'untitled' not in event.src_path.lower() and '.~' not in event.src_path:
-                self.delete_notebook_md(event)
+            # If ``event.src_path`` and ``event.dest_path`` match, the notebook
+            # was not renamed. Use ``event.dest_path`` if the file was renamed.
+            try:
+                notebook_path = Path(event.dest_path)
+            except AttributeError:
+                notebook_path = Path(event.src_path)
+            # This if-else block captures modified notebooks which do not
+            # have updated metadata. If a notebook does not have the updated
+            # metadata, the metadata is updated and since the notebook is
+            # altered ``def on_modified`` is called subsequently.
+            if not self.get_render_to_field(notebook_path):
+                print(f'Info - Modified {notebook_path} has no render-to '
+                      f'field.')
+                update_notebook_metadata(notebook_path)
+            elif self.get_slug_field(notebook_path) != notebook_path.stem:
+                print(f'Info - Modified {notebook_path} is not correctly '
+                      f'named.')
+                update_notebook_name(notebook_path,
+                                     self.get_slug_field(notebook_path))
+            else:
+                print(f'Info - Notebook {notebook_path} has render-to field.')
 
-                # if not self.notebook_metadata.get(event.src_path):
-                #     self.update_notebook_metadata_registry(event.src_path)
+                render_to = self.get_render_to_field(notebook_path)
+                self.delete_notebook_md(notebook_path)
 
-
-                # update metadata registry
-                self.update_notebook_metadata_registry(event)
-
-                render_to = self.get_render_to_field(event)
-
-                rendered = write_hugo_formatted_nb_to_md(event.src_path, render_to=render_to)
-
-                self.notebook_render[event.src_path].add(rendered)
+                write_hugo_formatted_nb_to_md(
+                    notebook_path, render_to=render_to)
 
         except Exception as e:
-            print('could not successfully render', event.src_path)
-            print(e)
-
+            print(f'Error - Could not render {event.src_path} successfully.')
+            raise e
 
     def on_modified(self, event):
+        """If a file is modified, process the notebook."""
+        print('Event - Modified - Sleeps 5 sec.')
+        time.sleep(5)
         self.process(event)
 
     def on_created(self, event):
-        # update notebook metadata as appropriate
+        """If a file is created, update the notebook metadata. Since this
+        process alters the notebook, ``def on_modified`` is called
+        automatically afterwards."""
+        print('Event - Created')
         update_notebook_metadata(event.src_path)
-        self.process(event)
 
     def on_deleted(self, event):
+        print('Event - Deleted')
         self.delete_notebook_md(event)
 
-    def delete_notebook_md(self, event):
-        print(crayons.yellow("attempting to delete the post for {}".format(event.src_path)))
-        for path in self.notebook_render[event.src_path]:
-            if path.exists():
-                path.unlink()
-                print(crayons.yellow('removed post: {}'.format(path)))
+    @staticmethod
+    def delete_notebook_md(notebook_path: Path):
+        print(f"Info - Attempting to delete the post for {notebook_path}")
+        # There are two possible ways to call the function. First, the function
+        # is called via ``def process`` and the ``render_to`` field exists.
+        # Then, there are two cases where ``render_to`` was changed which
+        # caused the event and where it did not change. Second, this function
+        # is called via ``def on_deleted``. In the second case, it is clear
+        # that the information on ``render_to`` is gone with the notebook and
+        # we have to look in each folder. In all of the cases we cannot be sure
+        # where the notebook was previously located. Therefore, loop through
+        # the directories and do not name notebooks and articles the same!
+        for render_to in ['content/blog/', 'content/post/']:
+            content_type = Path(render_to).stem
+            markdown_path = Path(render_to, str(notebook_path.stem) + '.md')
+            print(str(markdown_path))
+            if markdown_path.exists():
+                # Remove post
+                markdown_path.unlink()
+                # Remove resources
+                path_resources = Path('static', 'resources', content_type,
+                                      markdown_path.stem)
+                shutil.rmtree(str(path_resources))
+                print(f'Info - Removed post and resources: {str(path)}, '
+                      f'{path_resources}')
+            else:
+                print('Info - Post does not exist')
 
-    def update_notebook_metadata_registry(self, event):
+    @staticmethod
+    def get_render_to_field(notebook_path: Path) -> str:
+        """Tries to get the ``render-to`` field from the notebook and returns
+        and empty string if it does not exist."""
         try:
-            self.notebook_metadata[event.src_path] = json.loads(
-                Path(event.src_path).read_text())['metadata']
-        except json.JSONDecodeError:
-            print(crayons.yellow("Could not decode as json file: {}".format(event.src_path)))
-
-    def get_render_to_field(self, event) -> Optional[Path]:
-        try:
-            return self.notebook_metadata[event.src_path].get('hugo-jupyter', {}).get('render-to')
-        except json.JSONDecodeError:
-            print(crayons.yellow("could not marshal notebook to json: {}".format(event.src_path)))
+            render_to = json.loads(
+                notebook_path.read_text())[
+                    'metadata']['hugo-jupyter']['render-to']
+            return render_to
+        except json.JSONDecodeError as e:
+            print(crayons.yellow(
+                f"could not marshal notebook to json: {notebook_path}"))
+            raise e
         except KeyError:
-            print("{} has no field hugo-jupyter.render-to in its metadata".format(event.src_path))
+            print(f"{notebook_path} has no field hugo-jupyter.render-to in"
+                  "its metadata")
+            return ''
+
+    @staticmethod
+    def get_slug_field(notebook_path: Path) -> str:
+        """Tries to get the ``render-to`` field from the notebook and returns
+        and empty string if it does not exist."""
+        try:
+            slug = json.loads(
+                notebook_path.read_text())[
+                    'metadata']['front-matter']['slug']
+            return slug
+        except json.JSONDecodeError as e:
+            print(crayons.yellow(
+                f"could not marshal notebook to json: {notebook_path}"))
+            raise e
+        except KeyError:
+            print(f"{notebook_path} has no field hugo-jupyter.render-to in"
+                  "its metadata")
+            return ''


### PR DESCRIPTION
Hey,

first of all, thanks for making this project as I was desperately in need of such a package. I scripted my own rendering for jupyter notebooks but it missed the elegance of your approach with watchdog by far.

Unfortunately, I had some problems using the latest version which were
- unable to open the browser for jupyter (windows does not support ``open ...``)
- infinite building loops
- resources (images in output fields of the notebook) were not build and not saved to the appropriate folder in hugo (``static/...``)

Therefore, I went through ``fabfile.py`` and made multiple adjustments. Some of them are probably due to the fact that I did not understand your implementation strategy very well. For example, why did you choose to save notebook metadata and paths in class variables of the handler? You surely have a good reason, but for my mental structure of the program, it was easier to delete this necessity.

Also, I do not mean that this PR should be merged. It is probably more appropriate that it serves as a list for some feature enhancements which are fleshed out in separate PRs.

Here is the list of new features:
- [Fix 1](https://github.com/tobiasraabe/hugo_jupyter/blob/279c80bbf64bef5a4170d90c53fbce949cb80452/hugo_jupyter/__fabfile.py#L66) implements a cross-platform solution to open jupyter in the default browser
- [Fix 2](https://github.com/tobiasraabe/hugo_jupyter/blob/279c80bbf64bef5a4170d90c53fbce949cb80452/hugo_jupyter/__fabfile.py#L339) handles events for files which should be ignored replacing the if statements
- [Fix 3](https://github.com/tobiasraabe/hugo_jupyter/blob/279c80bbf64bef5a4170d90c53fbce949cb80452/hugo_jupyter/__fabfile.py#L238-L251) builds the markdown file to ``content/<post>/<slug>`` and resources (images), if they exist, to ``static/<post>/resources/<slug>``
- [Fix 4](https://github.com/tobiasraabe/hugo_jupyter/blob/279c80bbf64bef5a4170d90c53fbce949cb80452/hugo_jupyter/__fabfile.py#L262) implements a toc field which yields ``"true"`` by default. But this highly depends on your custom toc.html partial
- [Fix 5](https://github.com/tobiasraabe/hugo_jupyter/blob/279c80bbf64bef5a4170d90c53fbce949cb80452/hugo_jupyter/__fabfile.py#L330-L457) rewrites ``NotebookHandler``. The problem with using watchdog is that it does detect when a file is modified by its own function calls which means that if the notebook is altered because metadata is added, a modified file event is raised. Two cases can occur: First, a notebook is created, then we need to update the metadata which will raise a file modified event. Second, if a notebook is modified, then we need to distinguish the cases in which the metadata is present or not. Updating the metadata will results in another call of ``on_modified``, but if the metadata is present, the notebook will be processed. This should eliminate the problem of infinite loops.

But there are also some unfixed problems with my approach:
- notebooks are forced to be named with the slug as it simplifies the deletion process if the notebook is deleted.
- when notebooks are deleted or modified, the ``render-to`` field is lost or potentially modified. Therefore, program will loop through ``content/post``, ``content/blog`` and ``static/resources/post``, ``static/resources/blog`` to remove all files identified by the slug.
- I put a sleep statement in ``on_modified`` which is an ugly hack to prevent errors when files are already used by other processes

Again, thanks for your work and I hope this helps you too!